### PR TITLE
Deprecation Example : SBN -> ISBN

### DIFF
--- a/src/models/books.js
+++ b/src/models/books.js
@@ -1,0 +1,27 @@
+import _ from 'lodash';
+
+const books = [
+  {
+    bid: '1',
+    title: 'Mobey Dick',
+    author: 'Herman Melville',
+    SBN: '12312',
+    ISBN: '11111'
+  },
+  {
+    bid: '2',
+    title: 'Brave New World',
+    author: 'Aldous Huxley',
+    SBN: '12345',
+    ISBN: '22222'
+  },
+  {
+    bid: '3',
+    title: '1984',
+    author: 'George Orwell',
+    SBN: '12312',
+    ISBN: '33333'
+  }
+];
+
+export const getBook = (bookId) => _.find(books, ({bid}) => bid === bookId);

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -6,6 +6,7 @@ schema {
 type Query {
   learner(lid: ID!): Learner
   learners(criteria: LearnerBioSearch!): [Learner]
+  book(bid: String!): Book
 }
 
 type Mutation {
@@ -29,4 +30,12 @@ type LearnerBio {
 input LearnerBioSignup {
   name: String
   age: Int
+}
+
+type Book {
+  bid: String!
+  title: String,
+  author: String,
+  SBN: String@deprecated(reason: "Replaced with the international standard. Please use ISBN instead."),
+  ISBN: String
 }

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,12 +1,14 @@
 import fs from 'fs';
 import { makeExecutableSchema } from 'graphql-tools';
 import { getLearner, searchLearners, signup } from './models/learners';
+import { getBook } from './models/books';
 
 const schemaDef = fs.readFileSync(`${__dirname}/schema.gql`, 'utf-8');
 const resolvers = {
   Query: {
     learner: (root, { lid }) => getLearner(lid),
-    learners: (root, { criteria }) => searchLearners(criteria)
+    learners: (root, { criteria }) => searchLearners(criteria),
+    book: (root, { bid }) => getBook(bid)
   },
 
   Mutation: {


### PR DESCRIPTION
Example of a deprecated field on the 'Book' query. This highlights how a field being returned (in this scenario SBN) can be deprecated in favor of a new field (ISBN).